### PR TITLE
Fix version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 **OK.css** is a
 [classless CSS framework](https://css-tricks.com/no-class-css-frameworks/). Dropping it into your HTML will make your page look decent — no need to reference documentation, think about responsiveness, or account for browser differences as long as your markup is semantically-correct.
 
-To use it, you can [download the CSS file directly](https://cdn.jsdelivr.net/gh/andrewh0/okcss@v1/dist/ok.min.css) or add the following line to your HTML `<head>`:
+To use it, you can [download the CSS file directly](https://cdn.jsdelivr.net/gh/andrewh0/okcss@1/dist/ok.min.css) or add the following line to your HTML `<head>`:
 
 ```
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/andrewh0/okcss@v1/dist/ok.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/andrewh0/okcss@1/dist/ok.min.css" />
 ```
 
 Note that [normalize.css](https://github.com/necolas/normalize.css/) is included in **OK.css**.

--- a/index.html
+++ b/index.html
@@ -50,13 +50,13 @@
           <p>
             To use it, you can
             <a
-              href="https://cdn.jsdelivr.net/gh/andrewh0/okcss@v1/dist/ok.min.css"
+              href="https://cdn.jsdelivr.net/gh/andrewh0/okcss@1/dist/ok.min.css"
               >download the CSS file directly</a
             >
             or add the following line to your HTML <code>&lt;head&gt;</code>:
           </p>
           <pre>
-&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/andrewh0/okcss@v1/dist/ok.min.css" /&gt;</pre
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/andrewh0/okcss@1/dist/ok.min.css" /&gt;</pre
           >
           <p>
             <b>OK.css</b> is somewhere between a CSS normalizer and a


### PR DESCRIPTION
## Context

I had previously thought that the version number in the JSDelivr URL needed to match the release tag exactly, but it seems to work correctly without the `v`. Right now, using `@v1` seems to retrieve v1.0.3 instead of the latest version, v1.2.0.

## Change Type

Indicate the type of change your pull request is:

- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `skip-release`
