### PR TITLE
Add author field to package.json to fix release error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "author": "andrewh0 <andrewh0@users.noreply.github.com>",
   "license": "MIT",
   "scripts": {
     "build": "yarn run gulp",


### PR DESCRIPTION
## Change Type

Indicate the type of change your pull request is:

- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `skip-release`

## Summary

Adds the `author` field to `package.json` to fix the `yarn auto shipit` error "Could not find a git name and email to commit with!". The `auto` release tool requires author information to create commits during the release process.