### PR TITLE
Fix author field format for auto release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
-  "author": "andrewh0 <andrewh0@users.noreply.github.com>",
+  "author": {
+    "name": "andrewh0",
+    "email": "andrewh0@users.noreply.github.com"
+  },
   "license": "MIT",
   "scripts": {
     "build": "yarn run gulp",


### PR DESCRIPTION
## Change Type

- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `skip-release`

## Summary

Change author from string to object format so the auto tool can properly read the name and email properties separately.