### PR TITLE
Fix release: use npm version hook for CSS version sync

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -7,8 +7,5 @@
   ],
   "owner": "andrewh0",
   "repo": "okcss",
-  "prereleaseBranches": ["next"],
-  "scripts": {
-    "afterVersion": "yarn build"
-  }
+  "prereleaseBranches": ["next"]
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "./scripts/build.sh",
     "deploy": "yarn build && mkdir -p _site && cp src/ok.css dist/ok.min.css index.html demo.html _site/",
     "start": "yarn run serve .",
+    "version": "yarn build && git add src/ok.css dist/ok.min.css",
     "release:dry": "yarn auto shipit --dry-run",
     "release": "yarn auto shipit"
   },


### PR DESCRIPTION
## Summary

Fixes release failure from #25. The `scripts` config key isn't supported in `.autorc`. Use npm's built-in `version` lifecycle hook instead.

The `version` script runs after the version bump in package.json but before the commit, so it can update the CSS files and stage them.

## Change Type

- [x] `patch`
- [ ] `minor`
- [ ] `major`
- [ ] `skip-release`