### PR TITLE
Fix broken demo images — source.unsplash.com/random is deprecated (503)

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -184,8 +184,8 @@ Auctor elit sed vulputate mi sit amet mauris commodo quis.</pre
           <audio controls=""></audio>
           <p>This is an image: <code>img</code></p>
           <img
-            src="https://source.unsplash.com/random/400x300"
-            alt="random placeholder image"
+            src="https://images.unsplash.com/photo-1718220216044-006f43e3a9b1?w=400&h=300&fit=crop&q=80"
+            alt="open-plan office workspace"
           />
           <p>
             Wrap the <code>img</code> in a <code>figure</code> to include a
@@ -193,8 +193,8 @@ Auctor elit sed vulputate mi sit amet mauris commodo quis.</pre
           </p>
           <figure>
             <img
-              src="https://source.unsplash.com/random/400x300"
-              alt="random placeholder image"
+              src="https://images.unsplash.com/photo-1572521165329-b197f9ea3da6?w=400&h=300&fit=crop&q=80"
+              alt="calm office environment"
             />
             <figcaption>
               This image is from <a href="https://unsplash.com/">Unsplash</a>.


### PR DESCRIPTION
Noticed the two `<img>` tags in `demo.html` (L187, L196) still hotlink `https://source.unsplash.com/random/400x300`. Unsplash deprecated the `source.unsplash.com/random` endpoint in mid-2024 and the endpoint now 503s, so anyone loading the demo currently sees broken image tiles where the Media section's examples are supposed to render.

This PR swaps both to specific, permanent `images.unsplash.com` photo URLs pinned to 400×300. I also updated `alt` text to describe each photo instead of saying "random placeholder image."

Zero JS/CSS changes. Minimal two-line diff.

For context on the endpoint change: https://help.unsplash.com/en/articles/8656599-unsplash-source-is-deprecated

If you'd rather ship local assets instead of hotlinking, I wrote a small CLI for exactly that: `tteg` — `uv tool install tteg; tteg save "office" ./demo/img --width 400 --height 300`. Repo: https://github.com/kiluazen/tteg. Happy to push a follow-up PR that swaps to local files if you prefer.

Thanks for okcss!